### PR TITLE
🔨 Refactor: 포인트 전환 & 펀딩 결제할 때 finished_status가 false가 되도록 리팩토링 & 펀딩 결제와 주문 결제 나누기

### DIFF
--- a/src/main/java/kcs/funding/fundingboost/domain/controller/FundingController.java
+++ b/src/main/java/kcs/funding/fundingboost/domain/controller/FundingController.java
@@ -59,9 +59,9 @@ public class FundingController {
      * 친구 펀딩 디테일 페이지 조회
      */
     @GetMapping("/friends/{fundingId}")
-    public ResponseDto<FriendFundingDetailDto> viewFreindsFundingDetail(@PathVariable("fundingId") Long fundingId,
+    public ResponseDto<FriendFundingDetailDto> viewFriendsFundingDetail(@PathVariable("fundingId") Long fundingId,
                                                                         @RequestParam(name = "memberId") Long memberId) {
-        return ResponseDto.ok(fundingService.viewFreindsFundingDetail(fundingId, memberId));
+        return ResponseDto.ok(fundingService.viewFriendsFundingDetail(fundingId, memberId));
     }
 
     /**

--- a/src/main/java/kcs/funding/fundingboost/domain/controller/PayController.java
+++ b/src/main/java/kcs/funding/fundingboost/domain/controller/PayController.java
@@ -3,7 +3,8 @@ package kcs.funding.fundingboost.domain.controller;
 import kcs.funding.fundingboost.domain.dto.common.CommonSuccessDto;
 import kcs.funding.fundingboost.domain.dto.global.ResponseDto;
 import kcs.funding.fundingboost.domain.dto.request.FriendPayProcessDto;
-import kcs.funding.fundingboost.domain.dto.request.PaymentDto;
+import kcs.funding.fundingboost.domain.dto.request.FundingPaymentDto;
+import kcs.funding.fundingboost.domain.dto.request.MyPayDto;
 import kcs.funding.fundingboost.domain.dto.response.FriendFundingPayingDto;
 import kcs.funding.fundingboost.domain.dto.response.MyPayViewDto;
 import kcs.funding.fundingboost.domain.service.pay.FriendPayService;
@@ -30,7 +31,7 @@ public class PayController {
      */
     @GetMapping("/order")
     public ResponseDto<MyPayViewDto> myOrderPayView(@RequestParam(name = "memberId") Long memberId) {
-        return ResponseDto.ok(myPayService.orderPay(memberId));
+        return ResponseDto.ok(myPayService.getMyOrderPay(memberId));
     }
 
     /**
@@ -38,16 +39,25 @@ public class PayController {
      */
     @GetMapping("/funding")
     public ResponseDto<MyPayViewDto> myFundingPayView(@RequestParam(name = "memberId") Long memberId) {
-        return ResponseDto.ok(myPayService.fundingPay(memberId));
+        return ResponseDto.ok(myPayService.getMyFundingPay(memberId));
     }
 
     /**
-     * 결제하기
+     * 상품 구매하기
      */
-    @PostMapping("")
-    public ResponseDto<CommonSuccessDto> payMyOrder(@RequestBody PaymentDto paymentDto,
+    @PostMapping("/order")
+    public ResponseDto<CommonSuccessDto> payMyOrder(@RequestBody MyPayDto paymentDto,
                                                     @RequestParam("memberId") Long memberId) {
-        return ResponseDto.ok(myPayService.pay(paymentDto, memberId));
+        return ResponseDto.ok(myPayService.payMyItem(paymentDto, memberId));
+    }
+
+    /**
+     * 펀딩 상품 구매하기
+     */
+    @PostMapping("/funding")
+    public ResponseDto<CommonSuccessDto> payMyFunding(@RequestBody FundingPaymentDto fundingPaymentDto,
+                                                      @RequestParam("memberId") Long memberId) {
+        return ResponseDto.ok(myPayService.payMyFunding(fundingPaymentDto, memberId));
     }
 
     /**

--- a/src/main/java/kcs/funding/fundingboost/domain/dto/request/FundingPaymentDto.java
+++ b/src/main/java/kcs/funding/fundingboost/domain/dto/request/FundingPaymentDto.java
@@ -1,0 +1,13 @@
+package kcs.funding.fundingboost.domain.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record FundingPaymentDto(Long fundingItemId, int usingPoint) {
+    public static FundingPaymentDto fromEntity(Long fundingItemId, int usingPoint) {
+        return FundingPaymentDto.builder()
+                .fundingItemId(fundingItemId)
+                .usingPoint(usingPoint)
+                .build();
+    }
+}

--- a/src/main/java/kcs/funding/fundingboost/domain/dto/request/MyPayDto.java
+++ b/src/main/java/kcs/funding/fundingboost/domain/dto/request/MyPayDto.java
@@ -3,9 +3,9 @@ package kcs.funding.fundingboost.domain.dto.request;
 import lombok.Builder;
 
 @Builder
-public record PaymentDto(int usingPoint) {
-    public static PaymentDto fromEntity(int usingPoint) {
-        return PaymentDto.builder()
+public record MyPayDto(int usingPoint) {
+    public static MyPayDto fromEntity(int usingPoint) {
+        return MyPayDto.builder()
                 .usingPoint(usingPoint)
                 .build();
     }

--- a/src/main/java/kcs/funding/fundingboost/domain/dto/response/MyPageFundingItemDto.java
+++ b/src/main/java/kcs/funding/fundingboost/domain/dto/response/MyPageFundingItemDto.java
@@ -12,14 +12,14 @@ public record MyPageFundingItemDto(
         String itemImageUrl,
         String optionName,
         int itemPercent,
-        boolean deliveryStatus
+        boolean finishedStatus
 ) {
     public static MyPageFundingItemDto fromEntity(
             Funding funding,
             Item item,
             int itemPercent,
-            boolean deliveryStatus
-    ){
+            boolean finishedStatus
+    ) {
         return MyPageFundingItemDto.builder()
                 .fundingId(funding.getFundingId())
                 .itemName(item.getItemName())
@@ -27,7 +27,7 @@ public record MyPageFundingItemDto(
                 .itemImageUrl(item.getItemImageUrl())
                 .optionName(item.getOptionName())
                 .itemPercent(itemPercent)
-                .deliveryStatus(deliveryStatus)
+                .finishedStatus(finishedStatus)
                 .build();
     }
 

--- a/src/main/java/kcs/funding/fundingboost/domain/entity/FundingItem.java
+++ b/src/main/java/kcs/funding/fundingboost/domain/entity/FundingItem.java
@@ -47,8 +47,8 @@ public class FundingItem extends BaseTimeEntity {
     private boolean itemStatus;
 
     @NotNull
-    @Column(name = "delivery_status")
-    private boolean deliveryStatus;
+    @Column(name = "finished_status")
+    private boolean finishedStatus;
 
     public static FundingItem createFundingItem(Funding funding, Item item, int itemSequence) {
         FundingItem fundingItem = new FundingItem();
@@ -56,7 +56,11 @@ public class FundingItem extends BaseTimeEntity {
         fundingItem.item = item;
         fundingItem.itemSequence = itemSequence;
         fundingItem.itemStatus = false;
-        fundingItem.deliveryStatus = false;
+        fundingItem.finishedStatus = true;
         return fundingItem;
+    }
+
+    public void finishFunding() {
+        this.finishedStatus = false;
     }
 }

--- a/src/main/java/kcs/funding/fundingboost/domain/service/FundingService.java
+++ b/src/main/java/kcs/funding/fundingboost/domain/service/FundingService.java
@@ -103,7 +103,7 @@ public class FundingService {
         return CommonSuccessDto.fromEntity(true);
     }
 
-    public FriendFundingDetailDto viewFreindsFundingDetail(Long fundingId, Long memberId) {
+    public FriendFundingDetailDto viewFriendsFundingDetail(Long fundingId, Long memberId) {
 
         List<FundingItem> fundingItems = fundingItemRepository.findAllByFundingId(fundingId);
         List<FriendFundingItemDto> friendFundingItemList = fundingItems.stream().map(FriendFundingItemDto::fromEntity)

--- a/src/main/java/kcs/funding/fundingboost/domain/service/MyPageService.java
+++ b/src/main/java/kcs/funding/fundingboost/domain/service/MyPageService.java
@@ -20,7 +20,6 @@ import kcs.funding.fundingboost.domain.entity.Member;
 import kcs.funding.fundingboost.domain.exception.CommonException;
 import kcs.funding.fundingboost.domain.exception.ErrorCode;
 import kcs.funding.fundingboost.domain.repository.ContributorRepository;
-import kcs.funding.fundingboost.domain.repository.FundingItem.FundingItemRepository;
 import kcs.funding.fundingboost.domain.repository.MemberRepository;
 import kcs.funding.fundingboost.domain.repository.funding.FundingRepository;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +32,6 @@ public class MyPageService {
 
     private final FundingRepository fundingRepository;
     private final MemberRepository memberRepository;
-    private final FundingItemRepository fundingItemRepository;
     private final ContributorRepository contributorRepository;
 
     @Transactional
@@ -52,6 +50,7 @@ public class MyPageService {
                 collectPrice -= sortedFundingItem.getItem().getItemPrice();
             } else {
                 member.plusPoint(collectPrice);
+                sortedFundingItem.finishFunding();
                 return CommonSuccessDto.fromEntity(true);
             }
         }
@@ -104,7 +103,7 @@ public class MyPageService {
                 itemPercent = collectPrice * 100 / fundingItem.getItem().getItemPrice();
             }
             myPageFundingItemList.add(MyPageFundingItemDto.fromEntity(funding, fundingItem.getItem(), itemPercent,
-                    fundingItem.isDeliveryStatus()));
+                    fundingItem.isFinishedStatus()));
         }
 
         return myPageFundingItemList;

--- a/src/main/java/kcs/funding/fundingboost/domain/service/pay/MyPayService.java
+++ b/src/main/java/kcs/funding/fundingboost/domain/service/pay/MyPayService.java
@@ -2,15 +2,18 @@ package kcs.funding.fundingboost.domain.service.pay;
 
 import java.util.List;
 import kcs.funding.fundingboost.domain.dto.common.CommonSuccessDto;
-import kcs.funding.fundingboost.domain.dto.request.PaymentDto;
+import kcs.funding.fundingboost.domain.dto.request.FundingPaymentDto;
+import kcs.funding.fundingboost.domain.dto.request.MyPayDto;
 import kcs.funding.fundingboost.domain.dto.response.DeliveryDto;
 import kcs.funding.fundingboost.domain.dto.response.ItemDto;
 import kcs.funding.fundingboost.domain.dto.response.MyPayViewDto;
 import kcs.funding.fundingboost.domain.entity.Delivery;
 import kcs.funding.fundingboost.domain.entity.Funding;
+import kcs.funding.fundingboost.domain.entity.FundingItem;
 import kcs.funding.fundingboost.domain.entity.Member;
 import kcs.funding.fundingboost.domain.entity.Order;
 import kcs.funding.fundingboost.domain.repository.DeliveryRepository;
+import kcs.funding.fundingboost.domain.repository.FundingItem.FundingItemRepository;
 import kcs.funding.fundingboost.domain.repository.MemberRepository;
 import kcs.funding.fundingboost.domain.repository.OrderRepository;
 import kcs.funding.fundingboost.domain.repository.funding.FundingRepository;
@@ -22,14 +25,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MyPayService {
-
     private final FundingRepository fundingRepository;
     private final DeliveryRepository deliveryRepository;
     private final OrderRepository orderRepository;
     private final MemberRepository memberRepository;
+    private final FundingItemRepository fundingItemRepository;
 
-    public MyPayViewDto fundingPay(Long memberId) {
-
+    public MyPayViewDto getMyFundingPay(Long memberId) {
         Funding funding = fundingRepository.findByMemberIdAndStatus(memberId, true);
         List<ItemDto> itemDtoList = funding.getFundingItems()
                 .stream()
@@ -44,7 +46,7 @@ public class MyPayService {
         return MyPayViewDto.fromEntity(itemDtoList, deliveryDtoList, funding);
     }
 
-    public MyPayViewDto orderPay(Long memberId) {
+    public MyPayViewDto getMyOrderPay(Long memberId) {
         List<Order> orders = orderRepository.findAllByMemberId(memberId);
         List<ItemDto> itemDtoList = orders.stream()
                 .map(ItemDto::fromEntity)
@@ -59,13 +61,26 @@ public class MyPayService {
     }
 
     @Transactional
-    public CommonSuccessDto pay(PaymentDto paymentDto, Long memberId) {
+    public CommonSuccessDto payMyItem(MyPayDto paymentDto, Long memberId) {
         Member findMember = memberRepository.findById(memberId).orElseThrow();
-        if (findMember.getPoint() - paymentDto.usingPoint() >= 0) {
-            findMember.minusPoint(paymentDto.usingPoint());
+        deductPointsIfPossible(findMember, paymentDto.usingPoint());
+        return CommonSuccessDto.fromEntity(true);
+    }
+
+    @Transactional
+    public CommonSuccessDto payMyFunding(FundingPaymentDto fundingPaymentDto, Long memberId) {
+        Member findMember = memberRepository.findById(memberId).orElseThrow();
+        FundingItem fundingItem = fundingItemRepository.findById(fundingPaymentDto.fundingItemId()).orElseThrow();
+        deductPointsIfPossible(findMember, fundingPaymentDto.usingPoint());
+        fundingItem.finishFunding();
+        return CommonSuccessDto.fromEntity(true);
+    }
+
+    private void deductPointsIfPossible(Member member, int points) {
+        if (member.getPoint() - points >= 0) {
+            member.minusPoint(points);
         } else {
             throw new RuntimeException("point가 부족합니다");
         }
-        return CommonSuccessDto.fromEntity(true);
     }
 }

--- a/src/main/java/kcs/funding/fundingboost/domain/service/pay/MyPayService.java
+++ b/src/main/java/kcs/funding/fundingboost/domain/service/pay/MyPayService.java
@@ -12,6 +12,8 @@ import kcs.funding.fundingboost.domain.entity.Funding;
 import kcs.funding.fundingboost.domain.entity.FundingItem;
 import kcs.funding.fundingboost.domain.entity.Member;
 import kcs.funding.fundingboost.domain.entity.Order;
+import kcs.funding.fundingboost.domain.exception.CommonException;
+import kcs.funding.fundingboost.domain.exception.ErrorCode;
 import kcs.funding.fundingboost.domain.repository.DeliveryRepository;
 import kcs.funding.fundingboost.domain.repository.FundingItem.FundingItemRepository;
 import kcs.funding.fundingboost.domain.repository.MemberRepository;
@@ -62,14 +64,16 @@ public class MyPayService {
 
     @Transactional
     public CommonSuccessDto payMyItem(MyPayDto paymentDto, Long memberId) {
-        Member findMember = memberRepository.findById(memberId).orElseThrow();
+        Member findMember = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_MEMBER));
         deductPointsIfPossible(findMember, paymentDto.usingPoint());
         return CommonSuccessDto.fromEntity(true);
     }
 
     @Transactional
     public CommonSuccessDto payMyFunding(FundingPaymentDto fundingPaymentDto, Long memberId) {
-        Member findMember = memberRepository.findById(memberId).orElseThrow();
+        Member findMember = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_MEMBER));
         FundingItem fundingItem = fundingItemRepository.findById(fundingPaymentDto.fundingItemId()).orElseThrow();
         deductPointsIfPossible(findMember, fundingPaymentDto.usingPoint());
         fundingItem.finishFunding();


### PR DESCRIPTION
### 개요

### 변경사항
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
### 관련 지라 및 위키 링크
[FB-num](https://kcsfinalproject.atlassian.net/browse/FB-num)
### 리뷰어에게 하고 싶은 말

---
### 변경 사항
1. FundingItem의 deliveryStatus -> finishedStatus로 변경
2. 포인트 전환 클릭 시 finishedStatus를 true로 변경 (생성 시 false)
3. `친구 펀딩 디테일 페이지 조회` 메서드 명 오타 수정
4. 상품 구매 버튼 & 펀딩 상품 구매 버튼 나누기

---
### 시나리오 : memberId = 1인 사용자가 funding_item_id= 1, 2인 상품을 포인트 전환하기 클릭한 경우  각 상품의 finishedStatus가 false로 변경된다.

<img width="1326" alt="image" src="https://github.com/FundingBoost/FundingBoost-Server/assets/60764632/5d638234-6b47-497b-baa2-4e7f462278f8">

<img width="920" alt="image" src="https://github.com/FundingBoost/FundingBoost-Server/assets/60764632/2a440c15-4b3d-4cbe-bf09-d6f66d3eeef3">

