### PR TITLE
✅ MemberController Junit Test 구현 및 exchangePoint PatchMapping으로 변경

### DIFF
--- a/src/main/java/kcs/funding/fundingboost/domain/controller/MemberController.java
+++ b/src/main/java/kcs/funding/fundingboost/domain/controller/MemberController.java
@@ -5,7 +5,7 @@ import kcs.funding.fundingboost.domain.dto.global.ResponseDto;
 import kcs.funding.fundingboost.domain.dto.request.myPage.myFundingStatus.TransformPointDto;
 import kcs.funding.fundingboost.domain.service.MemberService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,7 +18,7 @@ public class MemberController {
     /**
      * 포인트 전환하기
      */
-    @PostMapping("/api/v1/member/point")
+    @PatchMapping("/api/v1/member/point")
     public ResponseDto<CommonSuccessDto> exchangePoint(@RequestBody TransformPointDto transformPointDto,
                                                        @RequestParam("memberId") Long memberId) {
         return ResponseDto.ok(memberService.exchangePoint(transformPointDto));

--- a/src/test/java/kcs/funding/fundingboost/domain/controller/MemberControllerTest.java
+++ b/src/test/java/kcs/funding/fundingboost/domain/controller/MemberControllerTest.java
@@ -44,7 +44,6 @@ class MemberControllerTest {
     private Member member;
     private Funding funding;
     private Item item1;
-    private Item item2;
 
     @BeforeEach
     void setUp() throws NoSuchFieldException, IllegalAccessException {
@@ -65,20 +64,11 @@ class MemberControllerTest {
                 "샤넬",
                 "뷰티",
                 "00:00");
-        item2 = createItemId(
-                2L,
-                "NEW 루쥬 코코 밤(+샤넬 기프트 카드)",
-                51000,
-                "https://img1.kakaocdn.net/...",
-                "샤넬",
-                "뷰티",
-                "934 코랄린 [NEW]");
 
         FundingItem fundingItem = FundingItem.createFundingItem(funding, item1, 1);
         Field fundingItems = funding.getClass().getDeclaredField("fundingItems");
         fundingItems.setAccessible(true);
         fundingItems.set(funding, List.of(fundingItem));
-
     }
 
     @DisplayName("포인트 전환")

--- a/src/test/java/kcs/funding/fundingboost/domain/controller/MemberControllerTest.java
+++ b/src/test/java/kcs/funding/fundingboost/domain/controller/MemberControllerTest.java
@@ -1,0 +1,131 @@
+package kcs.funding.fundingboost.domain.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.List;
+import kcs.funding.fundingboost.domain.dto.common.CommonSuccessDto;
+import kcs.funding.fundingboost.domain.dto.request.myPage.myFundingStatus.TransformPointDto;
+import kcs.funding.fundingboost.domain.entity.Funding;
+import kcs.funding.fundingboost.domain.entity.FundingItem;
+import kcs.funding.fundingboost.domain.entity.Item;
+import kcs.funding.fundingboost.domain.entity.Member;
+import kcs.funding.fundingboost.domain.entity.Tag;
+import kcs.funding.fundingboost.domain.service.MemberService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ExtendWith(MockitoExtension.class)
+@WebMvcTest(MemberController.class)
+class MemberControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MemberService memberService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Member member;
+    private Funding funding;
+    private Item item1;
+    private Item item2;
+
+    @BeforeEach
+    void setUp() throws NoSuchFieldException, IllegalAccessException {
+        member = createMember();
+        Field memberId = member.getClass().getDeclaredField("memberId");
+        memberId.setAccessible(true);
+        memberId.set(member, 1L);
+        funding = createFunding();
+        Field fundingId = funding.getClass().getDeclaredField("fundingId");
+        fundingId.setAccessible(true);
+        fundingId.set(funding, 1L);
+
+        item1 = createItemId(
+                1L,
+                "NEW 루쥬 알뤼르 벨벳 뉘 블랑쉬 리미티드 에디션",
+                61000,
+                "https://img1.kakaocdn.net/...",
+                "샤넬",
+                "뷰티",
+                "00:00");
+        item2 = createItemId(
+                2L,
+                "NEW 루쥬 코코 밤(+샤넬 기프트 카드)",
+                51000,
+                "https://img1.kakaocdn.net/...",
+                "샤넬",
+                "뷰티",
+                "934 코랄린 [NEW]");
+
+        FundingItem fundingItem = FundingItem.createFundingItem(funding, item1, 1);
+        Field fundingItems = funding.getClass().getDeclaredField("fundingItems");
+        fundingItems.setAccessible(true);
+        fundingItems.set(funding, List.of(fundingItem));
+
+    }
+
+    @DisplayName("포인트 전환")
+    @Test
+    void exchangePoint() throws Exception {
+        TransformPointDto transformPointDto = new TransformPointDto(funding.getFundingId());
+        CommonSuccessDto commonSuccessDto = new CommonSuccessDto(true);
+
+        given(memberService.exchangePoint(transformPointDto)).willReturn(commonSuccessDto);
+
+        String content = objectMapper.writeValueAsString(transformPointDto);
+        System.out.println(content);
+        mockMvc.perform(patch("/api/v1/member/point")
+                        .param("memberId", String.valueOf(member.getMemberId()))
+                        .contentType(APPLICATION_JSON)
+                        .content(content))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.isSuccess").value(true));
+    }
+
+    private Funding createFunding() {
+        Funding funding = Funding.createFundingForTest(
+                member, "생일 선물 주세용", Tag.BIRTHDAY, 112000,
+                10000, LocalDateTime.of(2024, 4, 30, 23, 59));
+        return funding;
+    }
+
+    private static Member createMember() {
+        return Member.createMemberWithPoint("임창희", "dlackdgml3710@gmail.com", "",
+                "https://p.kakaocdn.net/th/talkp/wnbbRhlyRW/XaGAXxS1OkUtXnomt6S4IK/ky0f9a_110x110_c.jpg",
+                46000,
+                "", "aFxoWGFUZlV5SH9MfE9-TH1PY1JiV2JRaF83");
+    }
+
+    private static Item createItemId(
+            Long itemId1,
+            String itemName,
+            int itemPrice,
+            String itemImageUrl,
+            String brandName,
+            String category,
+            String optionName
+    ) throws NoSuchFieldException, IllegalAccessException {
+        Item item = Item.createItem(itemName, itemPrice, itemImageUrl, brandName, category, optionName);
+        Field itemId = item.getClass().getDeclaredField("itemId");
+        itemId.setAccessible(true);
+        itemId.set(item, itemId1);
+        return item;
+    }
+}


### PR DESCRIPTION
### 개요
MemberController Junit Test 구현
### 변경사항
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
### 관련 지라 및 위키 링크
[FB-93](https://kcsfinalproject.atlassian.net/browse/FB-93)
### 리뷰어에게 하고 싶은 말
![image](https://github.com/FundingBoost/FundingBoost-Server/assets/70644043/7b0cb5ad-6c1f-438c-9685-881890a4ec61)


[FB-93]: https://kcsfinalproject.atlassian.net/browse/FB-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ