### PR TITLE
🔨 펀딩 종료했을 때 펀딩 아이템 finishStatus 변경 및 테스트 코드 변경 및 Oauth 코드 수정

### DIFF
--- a/src/main/java/kcs/funding/fundingboost/domain/entity/FundingItem.java
+++ b/src/main/java/kcs/funding/fundingboost/domain/entity/FundingItem.java
@@ -77,4 +77,11 @@ public class FundingItem extends BaseTimeEntity {
         this.finishedStatus = false;
         FundingUtils.checkFundingFinished(funding); // funding이 종료되었는지 확인
     }
+
+    /**
+     * 펀딩이 종료되었을 때 펀딩 아이템 모인 돈 0원일 때
+     */
+    public void terminateFundingItemByZero() {
+        this.finishedStatus = false;
+    }
 }

--- a/src/main/java/kcs/funding/fundingboost/domain/repository/funding/FundingRepository.java
+++ b/src/main/java/kcs/funding/fundingboost/domain/repository/funding/FundingRepository.java
@@ -17,4 +17,10 @@ public interface FundingRepository extends JpaRepository<Funding, Long>, Funding
             " join fetch f.member m" +
             " where f.fundingId = :fundingId")
     Funding findMemberById(@Param("fundingId") Long fundingId);
+
+    @Query("select f from Funding f" +
+            " join fetch f.fundingItems fi" +
+            " join fetch fi.item i" +
+            " where f.fundingId = :fundingId")
+    Funding findFundingById(@Param("fundingId") Long fundingId);
 }

--- a/src/main/java/kcs/funding/fundingboost/domain/repository/funding/FundingRepositoryImpl.java
+++ b/src/main/java/kcs/funding/fundingboost/domain/repository/funding/FundingRepositoryImpl.java
@@ -38,7 +38,8 @@ public class FundingRepositoryImpl implements FundingRepositoryCustom {
         return queryFactory
                 .selectFrom(funding)
                 .join(funding.member, member).fetchJoin()
-                .where(funding.member.memberId.eq(memberId))
+                .where(funding.member.memberId.eq(memberId)
+                        .and(funding.fundingStatus.eq(false)))
                 .orderBy(funding.createdDate.desc())
                 .fetch();
     }

--- a/src/main/java/kcs/funding/fundingboost/domain/service/CustomOAuth2UserService.java
+++ b/src/main/java/kcs/funding/fundingboost/domain/service/CustomOAuth2UserService.java
@@ -34,7 +34,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final RelationshipRepository relationshipRepository;
-    private final RestClient restClient;
 
     @Override
     public CustomUserDetails loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {

--- a/src/test/java/kcs/funding/fundingboost/domain/service/FundingServiceTestCH.java
+++ b/src/test/java/kcs/funding/fundingboost/domain/service/FundingServiceTestCH.java
@@ -164,14 +164,14 @@ class FundingServiceTestCH {
         String expectDeadline = LocalDate.now().toString();
 
         // member에 대한 funding 생성
-        when(fundingRepository.findById(funding.getFundingId())).thenReturn(Optional.of(funding));
+        when(fundingRepository.findFundingById(funding.getFundingId())).thenReturn(funding);
 
         //when
         CommonSuccessDto commonSuccessDto = fundingService.terminateFunding(funding.getFundingId());
         //then
         assertNotNull(commonSuccessDto);
         assertTrue(commonSuccessDto.isSuccess());
-        verify(fundingRepository, times(1)).findById(any());
+        verify(fundingRepository, times(1)).findFundingById(any());
         assertEquals(expectDeadline, funding.getDeadline()
                 .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
     }
@@ -182,13 +182,14 @@ class FundingServiceTestCH {
     void terminateFunding_NotFoundFunding() throws NoSuchFieldException, IllegalAccessException {
         //given
         Funding funding = FundingFixture.Graduate(member);
-        when(fundingRepository.findById(funding.getFundingId())).thenReturn(Optional.empty());
+        when(fundingRepository.findFundingById(funding.getFundingId())).thenReturn(null);
         //when
         CommonException exception = assertThrows(CommonException.class, () ->
                 fundingService.terminateFunding(funding.getFundingId()));
         //then
         assertEquals(NOT_FOUND_FUNDING.getMessage(), exception.getMessage());
     }
+
 
     @DisplayName("친구 펀딩 목록 조회-성공")
     @Test


### PR DESCRIPTION
### 개요
펀딩 종료했을 때 펀딩 아이템의 percent가 0일 때 finishStatus를 false로 변경하여 나머지 펀딩 아이템이 잔여 금액 결제나 포인트 전환이나 배송지 입력을 했을 경우 펀딩이 끝날 수 있도록 함
### 변경사항
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
### 관련 지라 및 위키 링크
[FB-140](https://kcsfinalproject.atlassian.net/browse/FB-140)
### 리뷰어에게 하고 싶은 말


[FB-140]: https://kcsfinalproject.atlassian.net/browse/FB-140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ